### PR TITLE
feat: migrate to Promotion directives for v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,100 +3,117 @@
 This is a GitOps repository of a simple Kargo example for getting started.
 
 ### Features:
+
 * A Warehouse which monitors a container repository for new images
 * Three Stage (dev, staging, prod) deploy pipeline
 * Image tag promotion
-* Direct git commits to dev, staging
+* Direct Git commits to dev, staging
 * Pull request for promotion to prod
 
-This example does not require an Argo CD instance and so would work with any GitOps operator (Argo CD, Flux) that detects and deploys manifest changes from a path in a git repo automatically (e.g. using auto-sync).
+This example does not require an Argo CD instance and so would work with any
+GitOps operator (Argo CD, Flux) that detects and deploys manifest changes from
+a path in a Git repository automatically (e.g. using auto-sync).
 
 ## Requirements
 
-* Kargo v0.8 (for older Kargo versions, switch to the release-X.Y branch)
-* GitHub git and container repository
+* Kargo v0.9.x (for older Kargo versions, switch to the release-X.Y branch)
+* GitHub and a container registry (GHCR.io)
+* `git` and `docker` installed
 
 ## Instructions
 
 1. Fork this repo, then clone it locally (from your fork).
-2. Run the `personalize.sh` to customize the manifests to use your GitHub username.
-```
-./personalize.sh <yourgithubusername>
-```
-3. `git commit` the personalized changes
-```
-git commit -a -m "personalize manifests"
-git push
-```
+2. Run the `personalize.sh` to customize the manifests to use your GitHub
+   username:
+
+   ```shell
+   ./personalize.sh <yourgithubusername>
+   ```
+3. `git commit` the personalized changes:
+
+   ```shell
+   git commit -a -m "personalize manifests"
+   git push
+   ```
 4. Create a guestbook container image repository in your GitHub account. 
 
-The easiest way to create a new ghcr.io image repository, is by retagging/pushing an existing image with your github username:
+   The easiest way to create a new ghcr.io image repository, is by retagging and 
+   pushing an existing image with your GitHub username:
 
-```
-docker login ghcr.io
+   ```shell
+   docker login ghcr.io
 
-docker buildx imagetools create \
-    ghcr.io/akuity/guestbook:latest \
-    -t ghcr.io/<yourgithubusername>/guestbook:v0.0.1
-```
+   docker buildx imagetools create \
+     ghcr.io/akuity/guestbook:latest \
+     -t ghcr.io/<yourgithubusername>/guestbook:v0.0.1
+   ```
 
-You will now have a `guestbook` container image repository. e.g.:
-
-https://github.com/yourgithubusername/guestbook/pkgs/container/guestbook
+   You will now have a `guestbook` container image repository. e.g.:
+   https://github.com/yourgithubusername/guestbook/pkgs/container/guestbook
 
 5. Change guestbook container image repository to public.
 
-In the GitHub UI, navigate to the "guestbook" container repository, Package settings, and change the visibility of the package to public. This will allow Kargo to monitor this repository for new images, without requiring you to configuring Kargo with container image repository credentials.
+   In the GitHub UI, navigate to the "guestbook" container repository, Package
+   settings, and change the visibility of the package to public. This will allow
+   Kargo to monitor this repository for new images, without requiring you to 
+   configuring Kargo with container image repository credentials.
 
-![change-package-visibility](docs/change-package-visibility.png)
+   ![change-package-visibility](docs/change-package-visibility.png)
 
-6. Download and install the latest CLI from [Kargo Releases](https://github.com/akuity/kargo/releases)
+6. Download and install the latest CLI from [Kargo Releases](https://github.com/akuity/kargo/releases/latest)
 
-```
-./download-cli.sh /usr/local/bin/kargo
-```
+   ```shell
+   ./download-cli.sh /usr/local/bin/kargo
+   ```
 
-7. Login to kargo
+7. Login to Kargo:
 
-```
-kargo login --admin https://<kargo-url>
-```
+   ```shell
+   kargo login --admin https://<kargo-url>
+   ```
 
-8. Apply the Kargo manifests
+8. Apply the Kargo manifests:
 
-```
-kargo apply -f ./kargo
-```
+   ```shell
+   kargo apply -f ./kargo
+   ```
 
-9. Add git repository credentials to Kargo. This can also be done in the UI in the `kargo-simple` Project.
+9. Add the Git repository credentials to Kargo. This can also be done in the UI
+   in the `kargo-simple` Project.
 
-```
-kargo create credentials github-creds \
-    --project kargo-simple \
-    --git \
-    --username <yourgithubusername> \
-    --repo-url https://github.com/<yourgithubusername>/kargo-simple.git
-```
+   ```shell
+   kargo create credentials github-creds \
+     --project kargo-simple \
+     --git \
+     --username <yourgithubusername> \
+     --repo-url https://github.com/<yourgithubusername>/kargo-simple.git
+   ```
 
-As part of the promotion process, Kargo requires privileges to commit changes to your git repository, as well as the ability to create pull requests. Ensure that the given token has these privileges.
+   As part of the promotion process, Kargo requires privileges to commit changes
+   to your Git repository, as well as the ability to create pull requests. Ensure
+   that the given token has these privileges.
 
 10. Promote the image!
 
-You now have a Kargo Pipeline which promotes images from the guestbook container image repository, through a three-stage deploy pipeline. Visit the `kargo-simple` Project in the Kargo UI to see the deploy pipeline.
+    You now have a Kargo Pipeline which promotes images from the guestbook
+    container image repository, through a three-stage deploy pipeline. Visit
+    the `kargo-simple` Project in the Kargo UI to see the deploy pipeline.
 
-![pipeline](docs/pipeline.png)
+    ![pipeline](docs/pipeline.png)
 
-To promote, click the target icon to the left of the `dev` Stage, select the detected Freight, and click `Yes` to promote. Once promoted, the freight will be qualified to be promoted to downstream Stages (`staging`, `prod`).
+    To promote, click the target icon to the left of the `dev` Stage, select
+    the detected Freight, and click `Yes` to promote. Once promoted, the Freight
+    will be qualified to be promoted to downstream Stages (`staging`, `prod`).
 
 
 ## Simulating a release
 
 To simulate a release, simply retag an image with a newer semantic version. e.g.:
 
-```
+```shell
 docker buildx imagetools create \
-    ghcr.io/akuity/guestbook:latest \
-    -t ghcr.io/<yourgithubusername>/guestbook:v0.0.2
+  ghcr.io/akuity/guestbook:latest \
+  -t ghcr.io/<yourgithubusername>/guestbook:v0.0.2
 ```
 
 Then refresh the Warehouse in the UI to detect the new Freight.

--- a/kargo/stages.yaml
+++ b/kargo/stages.yaml
@@ -42,7 +42,6 @@ spec:
       - uses: git-push
         config:
           path: ./repository
-          targetBranch: main
       # If you have an Argo CD Application that should be synced after the Git
       # repository is updated, uncomment the following lines and specify the
       # app name.
@@ -100,7 +99,6 @@ spec:
       - uses: git-push
         config:
           path: ./repository
-          targetBranch: main
       # If you have an Argo CD Application that should be synced after the Git
       # repository is updated, uncomment the following lines and specify the
       # app name.

--- a/kargo/stages.yaml
+++ b/kargo/stages.yaml
@@ -12,19 +12,47 @@ spec:
       name: guestbook
     sources:
       direct: true
-  promotionMechanisms:
-    gitRepoUpdates:
-    - repoURL: https://github.com/akuity/kargo-simple.git
-      writeBranch: main
-      kustomize:
-        images:
-        - image: ghcr.io/akuity/guestbook
-          path: env/dev
-    # If you have an Argo CD application that should be synced after the git repo is updated,
-    # uncomment the following lines and specify the app name. Repeat for the other Stages.
-    # argoCDAppUpdates:
-    # - appName: guestbook-dev
-
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone the Git repository that contains the Kustomize configuration
+      # to the ./repository directory.
+      - uses: git-clone
+        config:
+          repoURL: https://github.com/akuity/kargo-simple.git
+          checkout:
+          - branch: main
+            path: ./repository
+      # Update the image in the Kustomize configuration located at ./env/dev
+      # in the repository.
+      - uses: kustomize-set-image
+        as: update-image
+        config:
+          path: ./repository/env/dev
+          images:
+          - image: ghcr.io/akuity/guestbook
+      # Commit the changes to the Git repository.
+      - uses: git-commit
+        as: commit
+        config:
+          path: ./repository
+          messageFromSteps:
+          - update-image
+      # Push the changes to the Git repository.
+      - uses: git-push
+        config:
+          path: ./repository
+          targetBranch: main
+      # If you have an Argo CD Application that should be synced after the Git
+      # repository is updated, uncomment the following lines and specify the
+      # app name.
+      # - uses: argocd-update
+      #   config:
+      #     apps:
+      #     - name: guestbook-dev
+      #       sources:
+      #       - repoURL: https://github.com/akuity/kargo-simple.git
+      #         desiredCommitFromStep: commit
 ---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
@@ -42,17 +70,47 @@ spec:
       direct: false
       stages:
         - dev
-  promotionMechanisms:
-    gitRepoUpdates:
-    - repoURL: https://github.com/akuity/kargo-simple.git
-      writeBranch: main
-      kustomize:
-        images:
-        - image: ghcr.io/akuity/guestbook
-          path: env/staging
-    # argoCDAppUpdates:
-    # - appName: guestbook-staging
-
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone the Git repository that contains the Kustomize configuration
+      # to the ./repository directory.
+      - uses: git-clone
+        config:
+          repoURL: https://github.com/akuity/kargo-simple.git
+          checkout:
+          - branch: main
+            path: ./repository
+      # Update the image in the Kustomize configuration located at ./env/staging
+      # in the repository.
+      - uses: kustomize-set-image
+        as: update-image
+        config:
+          path: ./repository/env/staging
+          images:
+          - image: ghcr.io/akuity/guestbook
+      # Commit the changes to the Git repository.
+      - uses: git-commit
+        as: commit
+        config:
+          path: ./repository
+          messageFromSteps:
+          - update-image
+      # Push the changes to the Git repository.
+      - uses: git-push
+        config:
+          path: ./repository
+          targetBranch: main
+      # If you have an Argo CD Application that should be synced after the Git
+      # repository is updated, uncomment the following lines and specify the
+      # app name.
+      # - uses: argocd-update
+      #   config:
+      #     apps:
+      #       - name: guestbook-staging
+      #         sources:
+      #         - repoURL: https://github.com/akuity/kargo-simple.git
+      #           desiredCommitFromStep: commit
 ---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
@@ -70,14 +128,58 @@ spec:
       direct: false
       stages:
         - staging
-  promotionMechanisms:
-    gitRepoUpdates:
-    - repoURL: https://github.com/akuity/kargo-simple.git
-      writeBranch: main
-      kustomize:
-        images:
-        - image: ghcr.io/akuity/guestbook
-          path: env/prod
-      pullRequest: {}
-    # argoCDAppUpdates:
-    # - appName: guestbook-prod
+  promotionTemplate:
+    spec:
+      steps:
+      # Clone the Git repository that contains the Kustomize configuration
+      # to the ./repository directory.
+      - uses: git-clone
+        config:
+          repoURL: https://github.com/akuity/kargo-simple.git
+          checkout:
+            - branch: main
+              path: ./repository
+      # Update the image in the Kustomize configuration located at ./env/prod
+      # in the repository.
+      - uses: kustomize-set-image
+        as: update-image
+        config:
+          path: ./repository/env/prod
+          images:
+          - image: ghcr.io/akuity/guestbook
+      # Commit the changes to the Git repository.
+      - uses: git-commit
+        as: commit
+        config:
+          path: ./repository
+          messageFromSteps:
+          - update-image
+      # Push the changes to a newly created branch in the Git repository.
+      - uses: git-push
+        as: push
+        config:
+          path: ./repository
+          generateTargetBranch: true
+      # Open a pull request to merge the changes into the main branch.
+      - uses: git-open-pr
+        as: open-pr
+        config:
+          repoURL: https://github.com/akuity/kargo-simple.git
+          sourceBranchFromStep: push
+          targetBranch: main
+      # Wait for the pull request to be merged.
+      - uses: git-wait-for-pr
+        as: wait-for-pr
+        config:
+          repoURL: https://github.com/akuity/kargo-simple.git
+          prNumberFromStep: open-pr
+      # If you have an Argo CD Application that should be synced after the Git
+      # repository is updated, uncomment the following lines and specify the
+      # app name.
+      # - uses: argocd-update
+      #   config:
+      #     apps:
+      #     - name: guestbook-prod
+      #       sources:
+      #       - repoURL: https://github.com/akuity/kargo-simple.git
+      #         desiredCommitFromStep: commit

--- a/kargo/stages.yaml
+++ b/kargo/stages.yaml
@@ -16,32 +16,32 @@ spec:
     spec:
       steps:
       # Clone the Git repository that contains the Kustomize configuration
-      # to the ./repository directory.
+      # to the ./src directory.
       - uses: git-clone
         config:
           repoURL: https://github.com/akuity/kargo-simple.git
           checkout:
-          - branch: main
-            path: ./repository
+          - fromFreight: true
+            path: ./src
       # Update the image in the Kustomize configuration located at ./env/dev
       # in the repository.
       - uses: kustomize-set-image
         as: update-image
         config:
-          path: ./repository/env/dev
+          path: ./src/env/dev
           images:
           - image: ghcr.io/akuity/guestbook
       # Commit the changes to the Git repository.
       - uses: git-commit
         as: commit
         config:
-          path: ./repository
+          path: ./src
           messageFromSteps:
           - update-image
       # Push the changes to the Git repository.
       - uses: git-push
         config:
-          path: ./repository
+          path: ./src
       # If you have an Argo CD Application that should be synced after the Git
       # repository is updated, uncomment the following lines and specify the
       # app name.
@@ -68,37 +68,37 @@ spec:
     sources:
       direct: false
       stages:
-        - dev
+      - dev
   promotionTemplate:
     spec:
       steps:
       # Clone the Git repository that contains the Kustomize configuration
-      # to the ./repository directory.
+      # to the ./src directory.
       - uses: git-clone
         config:
           repoURL: https://github.com/akuity/kargo-simple.git
           checkout:
-          - branch: main
-            path: ./repository
+          - fromFreight: true
+            path: ./src
       # Update the image in the Kustomize configuration located at ./env/staging
       # in the repository.
       - uses: kustomize-set-image
         as: update-image
         config:
-          path: ./repository/env/staging
+          path: ./src/env/staging
           images:
           - image: ghcr.io/akuity/guestbook
       # Commit the changes to the Git repository.
       - uses: git-commit
         as: commit
         config:
-          path: ./repository
+          path: ./src
           messageFromSteps:
           - update-image
       # Push the changes to the Git repository.
       - uses: git-push
         config:
-          path: ./repository
+          path: ./src
       # If you have an Argo CD Application that should be synced after the Git
       # repository is updated, uncomment the following lines and specify the
       # app name.
@@ -125,38 +125,38 @@ spec:
     sources:
       direct: false
       stages:
-        - staging
+      - staging
   promotionTemplate:
     spec:
       steps:
       # Clone the Git repository that contains the Kustomize configuration
-      # to the ./repository directory.
+      # to the ./src directory.
       - uses: git-clone
         config:
           repoURL: https://github.com/akuity/kargo-simple.git
           checkout:
-            - branch: main
-              path: ./repository
+          - fromFreight: true
+            path: ./src
       # Update the image in the Kustomize configuration located at ./env/prod
       # in the repository.
       - uses: kustomize-set-image
         as: update-image
         config:
-          path: ./repository/env/prod
+          path: ./src/env/prod
           images:
           - image: ghcr.io/akuity/guestbook
       # Commit the changes to the Git repository.
       - uses: git-commit
         as: commit
         config:
-          path: ./repository
+          path: ./src
           messageFromSteps:
           - update-image
       # Push the changes to a newly created branch in the Git repository.
       - uses: git-push
         as: push
         config:
-          path: ./repository
+          path: ./src
           generateTargetBranch: true
       # Open a pull request to merge the changes into the main branch.
       - uses: git-open-pr


### PR DESCRIPTION
This updates the examples to use Promotion (directive) steps, which will become available in Kargo v0.9.0.

⚠️ Draft until v0.9.0 is actually released.