### PR TITLE
chore: update the script to ensure compatibility with OS

### DIFF
--- a/personalize.sh
+++ b/personalize.sh
@@ -9,13 +9,20 @@ username=$1
 repository_name=$2
 image_name=$3
 
-find . -type f -name '*.yaml' -exec sed -E -i '' s#https://github.com/[-_a-zA-Z0-9]+#https://github.com/${username}#g {} +
-find . -type f -name '*.yaml' -exec sed -E -i '' s#ghcr.io/[-_a-zA-Z0-9]+#ghcr.io/${username}#g {} +
+# Detect OS and set sed flag accordingly
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SED_OPTS="-E -i ''"
+else
+  SED_OPTS="-E -i"
+fi
+
+find . -type f -name '*.yaml' -exec sed $SED_OPTS s#https://github.com/[-_a-zA-Z0-9]+#https://github.com/${username}#g {} +
+find . -type f -name '*.yaml' -exec sed $SED_OPTS s#ghcr.io/[-_a-zA-Z0-9]+#ghcr.io/${username}#g {} +
 
 if [ ! -z "$repository_name" ]; then
-  find . -type f -name '*.yaml' -exec sed -E -i '' "s#https://github.com/${username}/[-_a-zA-Z0-9]+#https://github.com/${username}/${repository_name}#g" {} +
+  find . -type f -name '*.yaml' -exec sed $SED_OPTS "s#https://github.com/${username}/[-_a-zA-Z0-9]+#https://github.com/${username}/${repository_name}#g" {} +
 fi
 
 if [ ! -z "$image_name" ]; then
-  find . -type f -name '*.yaml' -exec sed -E -i '' "s#ghcr.io/${username}/[-_a-zA-Z0-9]+#ghcr.io/${username}/${image_name}#g" {} +
+  find . -type f -name '*.yaml' -exec sed $SED_OPTS "s#ghcr.io/${username}/[-_a-zA-Z0-9]+#ghcr.io/${username}/${image_name}#g" {} +
 fi


### PR DESCRIPTION
I'm using Linux (Ubuntu) to run the [personalize script](https://github.com/akuity/kargo-simple/blob/main/personalize.sh) but I got the following error
```
> ./personalize.sh nitishfy
sed: can't read s#https://github.com/[-_a-zA-Z0-9]+#https://github.com/nitishfy#g: No such file or directory
sed: can't read s#ghcr.io/[-_a-zA-Z0-9]+#ghcr.io/nitishfy#g: No such file or directory

> ./personalize.sh 'nitishfy'
sed: can't read s#https://github.com/[-_a-zA-Z0-9]+#https://github.com/nitishfy#g: No such file or directory
sed: can't read s#ghcr.io/[-_a-zA-Z0-9]+#ghcr.io/nitishfy#g: No such file or directory            

> ./personalize.sh "nitishfy"
sed: can't read s#https://github.com/[-_a-zA-Z0-9]+#https://github.com/nitishfy#g: No such file or directory
sed: can't read s#ghcr.io/[-_a-zA-Z0-9]+#ghcr.io/nitishfy#g: No such file or directory
```

The issue is likely due to the `-i ''` syntax, which is specific to macOS but does not work on Linux.