### PR TITLE
fix: update docs to point to the correct link for guestbook container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ a path in a Git repository automatically (e.g. using auto-sync).
    ```
 
    You will now have a `guestbook` container image repository. e.g.:
-   https://github.com/yourgithubusername/guestbook/pkgs/container/guestbook
+   https://github.com/users/yourgithubusername/packages/container/package/guestbook
 
 5. Change guestbook container image repository to public.
 


### PR DESCRIPTION
## Background

This pull request includes a small update to the `README.md` file to correct the URL format for the guestbook container image repository.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53): Updated the URL for the guestbook container image repository to reflect the correct format.

## Test
Tested by manually accessing the link, before and after.