### PR TITLE
fix: update prNumber ref in git-wait-for-pr

### DIFF
--- a/kargo/promotiontask.yaml
+++ b/kargo/promotiontask.yaml
@@ -65,7 +65,7 @@ spec:
     if: ${{ vars.openpr == 'true' }}
     config:
       repoURL: ${{ vars.repoURL }}
-      prNumber: ${{ task.outputs['open-pr'].prNumber }}
+      prNumber: ${{ task.outputs['open-pr'].pr.id }}
 
   # If you have an Argo CD Application that should be synced after the Git
   # repository is updated, uncomment the following lines and specify the


### PR DESCRIPTION
This fixes a broken ref to the `git-open-pr` output.

https://docs.kargo.io/user-guide/reference-docs/promotion-steps/git-open-pr/#output